### PR TITLE
Added safety checks for staticServeConfig

### DIFF
--- a/packages/core/lib/rest/http-server/server.ts
+++ b/packages/core/lib/rest/http-server/server.ts
@@ -80,7 +80,14 @@ export class HyperServer {
 
   configureStaticServer() {
     const staticServeConfig = ConfigService.get('http.staticServe');
-    if (!staticServeConfig.filePath || !staticServeConfig.httpPath) return;
+
+    if (!staticServeConfig || typeof staticServeConfig !== "object") {
+      return;
+    }
+
+    if (!staticServeConfig.filePath || !staticServeConfig.httpPath) {
+      return;
+    }
 
     const liveAssets = new LiveDirectory(staticServeConfig.filePath, {
       static: true,


### PR DESCRIPTION
This PR fixes the following problem:

`http.staticServe` is marked as optional in `packages/core/lib/interfaces/config.ts`
 
 
https://github.com/intentjs/intent/blob/80d0b33e2fed32b30ccb90ebfff291c38b9070a1/packages/core/lib/interfaces/config.ts#L36-L50

This means that if you opt-out of static serving files (like I did, I wanted to create a simple-as-possible sample application because I'm developing a plugin so I don't need most of the things), the code is going to crash.

Two were the places where an intervention could be made: either in the place where I edited the code or in the interface.

Because I didn't know if `http.staticServe` config path is optional by mistake (please tell me it is), I rathered to use the first one because it is the least breaking path (not a breaking change).

Let me know.