### PR TITLE
chore: update dev and build scripts for intent@0.1.38

### DIFF
--- a/integrations/sample-app/package.json
+++ b/integrations/sample-app/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/intentjs/new-app-starter",
   "scripts": {
-    "dev": "intent start --watch",
-    "build": "intent build",
+    "dev": "node intent dev",
+    "build": "node intent build",
     "format": "prettier --write \"app/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint \"{app,libs,test}/**/*.ts\" --fix",
     "format:check": "prettier --check \"app/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
This PR updates the dev and build scripts in the project to align with `intent@0.1.38`.

- Replaced the deprecated `intent start` command with `node intent dev`.
- Updated `intent build` to `node intent build` to reflect changes in the current version.