### PR TITLE
refactor(cache-drivers): added storekey method in inmemory driver for…

### DIFF
--- a/packages/core/lib/cache/drivers/dice-db.ts
+++ b/packages/core/lib/cache/drivers/dice-db.ts
@@ -11,7 +11,7 @@ export class DiceDbDriver implements CacheDriver {
 
   async get(key: string): Promise<any> {
     await this.initializeModules();
-    const value = await this.client.get(`${this.options.prefix}:::${key}`);
+    const value = await this.client.get(this.storeKey(key));
     if (!value) return null;
     try {
       return JSON.parse(value);
@@ -27,7 +27,7 @@ export class DiceDbDriver implements CacheDriver {
   ): Promise<boolean> {
     await this.initializeModules();
     try {
-      const redisKey = `${this.options.prefix}:::${key}`;
+      const redisKey = this.storeKey(key);
       ttlInSec
         ? await this.client.set(redisKey, JSON.stringify(value), 'EX', ttlInSec)
         : await this.client.set(redisKey, JSON.stringify(value));
@@ -39,7 +39,7 @@ export class DiceDbDriver implements CacheDriver {
 
   async has(key: string): Promise<boolean> {
     await this.initializeModules();
-    const num = await this.client.exists(`${this.options.prefix}:::${key}`);
+    const num = await this.client.exists(this.storeKey(key));
     return !!num;
   }
 

--- a/packages/core/lib/cache/drivers/inMemory.ts
+++ b/packages/core/lib/cache/drivers/inMemory.ts
@@ -11,7 +11,7 @@ export class InMemoryDriver implements CacheDriver {
 
   async get<T>(key: string): Promise<T> {
     await this.initialiseModules();
-    const cacheKey = `${this.options.prefix}:::${key}`;
+    const cacheKey = this.storeKey(key);
     return this.client.get(cacheKey);
   }
 
@@ -21,7 +21,7 @@ export class InMemoryDriver implements CacheDriver {
     ttlInSec?: number | undefined,
   ): Promise<boolean> {
     await this.initialiseModules();
-    const cacheKey = `${this.options.prefix}:::${key}`;
+    const cacheKey = this.storeKey(key);
 
     if (ttlInSec) {
       return this.client.set(cacheKey, value, ttlInSec);
@@ -32,7 +32,7 @@ export class InMemoryDriver implements CacheDriver {
 
   async has(key: string): Promise<boolean> {
     await this.initialiseModules();
-    const cacheKey = `${this.options.prefix}:::${key}`;
+    const cacheKey = this.storeKey(key);
     return this.client.has(cacheKey);
   }
 
@@ -70,12 +70,16 @@ export class InMemoryDriver implements CacheDriver {
   async forget(key: string): Promise<boolean> {
     await this.initialiseModules();
     try {
-      const cacheKey = `${this.options.prefix}:::${key}`;
+      const cacheKey = this.storeKey(key);
       await this.client.del(cacheKey);
       return true;
     } catch {
       return false;
     }
+  }
+
+  private storeKey(key: string): string {
+    return `${this.options.prefix}:::${key}`;
   }
 
   getClient<T>(): T {

--- a/packages/core/lib/cache/drivers/redis.ts
+++ b/packages/core/lib/cache/drivers/redis.ts
@@ -12,7 +12,7 @@ export class RedisDriver implements CacheDriver {
 
   async get(key: string): Promise<any> {
     await this.initializeModules();
-    const value = await this.client.get(`${this.options.prefix}:::${key}`);
+    const value = await this.client.get(this.storeKey(key));
     if (!value) return null;
     try {
       return JSON.parse(value);
@@ -28,7 +28,7 @@ export class RedisDriver implements CacheDriver {
   ): Promise<boolean> {
     await this.initializeModules();
     try {
-      const redisKey = `${this.options.prefix}:::${key}`;
+      const redisKey = this.storeKey(key);
       ttlInSec
         ? await this.client.set(redisKey, JSON.stringify(value), 'EX', ttlInSec)
         : await this.client.set(redisKey, JSON.stringify(value));
@@ -40,7 +40,7 @@ export class RedisDriver implements CacheDriver {
 
   async has(key: string): Promise<boolean> {
     await this.initializeModules();
-    const num = await this.client.exists(`${this.options.prefix}:::${key}`);
+    const num = await this.client.exists(this.storeKey(key));
     return !!num;
   }
 


### PR DESCRIPTION
1. Added `storeKey()` in `inMemory` cache driver class for consistency.
2. Use `storeKey()` in all places to maintain clean code.